### PR TITLE
To check mails for a valid html part strip tags when comparing

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -784,7 +784,9 @@ ORDER BY   i.contact_id, i.{$tempColumn}
         $this->templates['text'] = implode("\n", $template);
       }
 
-      if ($this->body_html) {
+      // To check for an html part strip tags
+      if (trim(strip_tags($this->body_html))) {
+
 
         $template = array();
         if ($this->header) {


### PR DESCRIPTION
CiviMail's HTML Editor inserts some invisible tag structure by default which makes it hard for authors to send mailings w/o html part (Choose source view, delete all). 

Should be better to strip tags when checking for a valid html part.
