### PR TITLE
Handle CRM-21423: Set defsault location type to primary

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -555,7 +555,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
       FALSE, FALSE, $queryMode,
-      FALSE, TRUE, TRUE, NULL, $queryOperator
+      FALSE, TRUE, TRUE, NULL, $queryOperator, NULL, TRUE
     );
 
     //sort by state


### PR DESCRIPTION
Disabling "Search Primary Details Only" breaks export of primary addresses because they are not chosen in Query.php.